### PR TITLE
feat: add proxy_configuration field to ecs task definition

### DIFF
--- a/src/command/ecs/executer.rs
+++ b/src/command/ecs/executer.rs
@@ -92,6 +92,10 @@ pub trait Executer {
             requires_compatibilities: task_definition_conf.requires_compatibilities.to_owned(),
             cpu: task_definition_conf.cpu.to_owned(),
             memory: task_definition_conf.memory.to_owned(),
+            proxy_configuration: task_definition_conf
+                .proxy_configuration
+                .as_ref()
+                .map(|pc| pc.to_rusoto()),
             ..Default::default()
         };
 

--- a/src/config/ecs.rs
+++ b/src/config/ecs.rs
@@ -26,6 +26,7 @@ pub struct TaskDefinition {
     pub execution_role_arn: Option<String>,
     pub cpu: Option<String>,
     pub memory: Option<String>,
+    pub proxy_configuration: Option<ProxyConfiguration>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -164,6 +165,25 @@ impl HostVolumeProperties {
     pub fn to_rusoto(&self) -> rusoto_ecs::HostVolumeProperties {
         rusoto_ecs::HostVolumeProperties {
             source_path: self.source_path.to_owned(),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct ProxyConfiguration {
+    pub container_name: String,
+    pub properties: Option<Vec<KeyValuePair>>,
+    pub type_: Option<String>,
+}
+impl ProxyConfiguration {
+    pub fn to_rusoto(&self) -> rusoto_ecs::ProxyConfiguration {
+        rusoto_ecs::ProxyConfiguration {
+            container_name: self.container_name.to_owned(),
+            properties: self
+                .properties
+                .as_ref()
+                .map(|p| p.iter().map(|p0| p0.to_rusoto()).collect()),
+            type_: self.type_.to_owned(),
         }
     }
 }


### PR DESCRIPTION
I have defined a field in the ecs task definition called `proxyConfiguration` that is used when deploying the app mesh managed envoy.

https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/APIReference/API_ProxyConfiguration.html

- [x] test deployment