### PR TITLE
chore: update cargo.toml v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "racco"
-version = "0.8.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "racco"
-version = "0.8.0"
+version = "0.9.1"
 authors = ["Daichi Sakai <daisaru11@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/micin-jp/racco"


### PR DESCRIPTION
I forgot to upgrade the version of `Cargo.toml` : https://github.com/micin-jp/racco/pull/11 